### PR TITLE
Fix error with missing client argument for http.begin()

### DIFF
--- a/ESP8266IFTTTWebhook.cpp
+++ b/ESP8266IFTTTWebhook.cpp
@@ -2,10 +2,11 @@
 #include "Arduino.h"
 #include "ESP8266IFTTTWebhook.h"
 
-ESP8266IFTTTWebhook::ESP8266IFTTTWebhook (String EVENT_NAME, String API_KEY)
+ESP8266IFTTTWebhook::ESP8266IFTTTWebhook (String EVENT_NAME, String API_KEY, WiFiClient CLIENT)
 {
 	_EVENT_NAME = EVENT_NAME;
 	_API_KEY = API_KEY;
+    _CLIENT = CLIENT;
 }
 
 
@@ -30,7 +31,7 @@ void ESP8266IFTTTWebhook::trigger(String value1, String value2, String value3)
 {
 	HTTPClient http;
 
-    http.begin("http://maker.ifttt.com/trigger/" + _EVENT_NAME + "/with/key/" + _API_KEY);
+    http.begin(_CLIENT, "http://maker.ifttt.com/trigger/" + _EVENT_NAME + "/with/key/" + _API_KEY);
     http.addHeader("Content-Type", "application/json");
 	
 	String values = "{\"value1\":\"" + value1 + "\", \"value2\":\"" + value2 + "\", \"value3\":\"" + value3 + "\"}";

--- a/ESP8266IFTTTWebhook.h
+++ b/ESP8266IFTTTWebhook.h
@@ -10,7 +10,7 @@
 class ESP8266IFTTTWebhook
 {
 	public:
-	ESP8266IFTTTWebhook (String EVENT_NAME, String API_KEY);
+	ESP8266IFTTTWebhook (String EVENT_NAME, String API_KEY, WiFiClient CLIENT);
     void trigger();
 	void trigger(String value1);
 	void trigger(String value1, String value2);
@@ -19,6 +19,7 @@ class ESP8266IFTTTWebhook
 	private:
 	String _EVENT_NAME;
 	String _API_KEY;
+    WiFiClient _CLIENT;
 };
 
 

--- a/examples/IFTTTWebhook_example/IFTTTWebhook_example.ino
+++ b/examples/IFTTTWebhook_example/IFTTTWebhook_example.ino
@@ -17,8 +17,9 @@ const char* WEBHOOK_NAME = "YOUR_EVENT_NAME";
 int current = 0;
 int last = 0;
 
+WiFiClient client;
 //Create ifttt object
-ESP8266IFTTTWebhook ifttt (WEBHOOK_NAME, API_KEY);
+ESP8266IFTTTWebhook ifttt (WEBHOOK_NAME, API_KEY, client);
 
 void setup() {
   Serial.begin(115200);


### PR DESCRIPTION
New HTTPClient API requires additional WiFiClient object as an argument to begin() function. 

This pull request creates new global WiFiClient object and changes the ESP8266IFTTTWebhook constructor to accept it as argument. Then the client is saved in private class variable and used in http.begin() function to fix the error.

This also modyfies the example to use this new required object.